### PR TITLE
fix directory upload to deliver expected directory structure

### DIFF
--- a/siaskynet/skynet.py
+++ b/siaskynet/skynet.py
@@ -79,7 +79,7 @@ class Skynet:
         files = list(Skynet.walk_directory(path).keys())
         for file in files:
             ftuples.append((opts.portal_directory_file_fieldname,
-                (file[len(path):], open(file, 'rb'))))
+                            (file[len(path):], open(file, 'rb'))))
 
         filename = opts.custom_filename if opts.custom_filename else path
 

--- a/siaskynet/skynet.py
+++ b/siaskynet/skynet.py
@@ -79,7 +79,7 @@ class Skynet:
         files = list(Skynet.walk_directory(path).keys())
         for file in files:
             ftuples.append((opts.portal_directory_file_fieldname,
-                            (file, open(file, 'rb'))))
+                (file[len(path):], open(file, 'rb'))))
 
         filename = opts.custom_filename if opts.custom_filename else path
 


### PR DESCRIPTION
This fix comes from this use case:

I want to upload a directory
I upload a director with the path /home/username/somedir
Current behavior:
The skylink directory structure will be SKYLINK_HASH/home/username/somedir/index.html

New behavior:
The skylink directory structure will be SKYLINK_HASH/index.html