### PR TITLE
Additional Metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="siaskynet",
-    version="1.0.2",
+    version="1.0.3",
     author="Peter-Jan Brone",
     author_email="peterjan.brone@gmail.com",
     description="Skynet SDK",

--- a/siaskynet/skynet.py
+++ b/siaskynet/skynet.py
@@ -110,12 +110,15 @@ class Skynet:
     @staticmethod
     def metadata(skylink, opts=None):
         r = Skynet.metadata_request(skylink, opts)
-        return {
+        result = {
             "Content-Length": r.headers["Content-Length"],
             "Content-Type": r.headers["Content-Type"],
-            "Content-Disposition": r.headers["Content-Disposition"],
-            "Skynet-File-Metadata": json.loads(r.headers["Skynet-File-Metadata"])
         }
+        if "Content-Disposition" in r.headers:
+            result["Content-Disposition"] = r.headers["Content-Disposition"]
+        if "Skynet-File-Metadata" in r.headers:
+            result["Skynet-File-Metadata"] = json.loads(r.headers["Skynet-File-Metadata"])
+        return result
 
     @staticmethod
     def metadata_request(skylink, opts=None, stream=False):

--- a/siaskynet/skynet.py
+++ b/siaskynet/skynet.py
@@ -110,7 +110,12 @@ class Skynet:
     @staticmethod
     def metadata(skylink, opts=None):
         r = Skynet.metadata_request(skylink, opts)
-        return json.loads(r.headers["skynet-file-metadata"])
+        return {
+            "Content-Length": r.headers["Content-Length"],
+            "Content-Type": r.headers["Content-Type"],
+            "Content-Disposition": r.headers["Content-Disposition"],
+            "Skynet-File-Metadata": json.loads(r.headers["Skynet-File-Metadata"])
+        }
 
     @staticmethod
     def metadata_request(skylink, opts=None, stream=False):

--- a/siaskynet/skynet.py
+++ b/siaskynet/skynet.py
@@ -110,6 +110,8 @@ class Skynet:
     @staticmethod
     def metadata(skylink, opts=None):
         r = Skynet.metadata_request(skylink, opts)
+        if r.status_code != 200:
+            return None
         result = {
             "Content-Length": r.headers["Content-Length"],
             "Content-Type": r.headers["Content-Type"],


### PR DESCRIPTION
I was working with the metadata feature and discovered the 'len' field is not included in chunked uploads.

So I've expanded the metadata provided to show the length and content-type from the HTTP headers, as they are available there.

It is good to know the length without needing to download the file.