### PR TITLE
Simple changes to add timeout

### DIFF
--- a/siaskynet/skynet.py
+++ b/siaskynet/skynet.py
@@ -23,6 +23,7 @@ class Skynet:
             'portal_upload_path': 'skynet/skyfile',
             'portal_file_fieldname': 'file',
             'portal_directory_file_fieldname': 'files[]',
+            'timeout_seconds': 35,
             'custom_filename': ''
         })
 
@@ -41,13 +42,13 @@ class Skynet:
         return string
 
     @staticmethod
-    def upload_file(path, opts=None, timeout=6):
+    def upload_file(path, opts=None):
         """Uploads file at path with the given options."""
-        skylink = Skynet.upload_file_request(path, opts, timeout).json()["skylink"]
+        skylink = Skynet.upload_file_request(path, opts).json()["skylink"]
         return Skynet.uri_skynet_prefix() + skylink
 
     @staticmethod
-    def upload_file_request(path, opts=None, timeout=6):
+    def upload_file_request(path, opts=None):
         """Posts request to upload file."""
         if opts is None:
             opts = Skynet.default_upload_options()
@@ -56,11 +57,15 @@ class Skynet:
             host = opts.portal_url
             path = opts.portal_upload_path
             url = host+'/'+path
+            if hasattr(opts, 'timeout_seconds'):
+                timeout = opts.timeout_seconds
+            else:
+                timeout = Skynet.default_upload_options().timeout_seconds
             r = requests.post(url, files={opts.portal_file_fieldname: fd}, timeout=timeout)
         return r
 
     @staticmethod
-    def upload_file_request_with_chunks(path, opts=None, timeout=6):
+    def upload_file_request_with_chunks(path, opts=None):
         """Posts request to upload file with chunks."""
         if opts is None:
             opts = Skynet.default_upload_options()
@@ -70,19 +75,23 @@ class Skynet:
         url = "%s/%s?filename=%s" % \
             (opts.portal_url, opts.portal_upload_path, filename)
         headers = {'Content-Type': 'application/octet-stream'}
+        if hasattr(opts, 'timeout_seconds'):
+            timeout = opts.timeout_seconds
+        else:
+            timeout = Skynet.default_upload_options().timeout_seconds
         r = requests.post(url, data=path, headers=headers, timeout=timeout)
         return r
 
     @staticmethod
-    def upload_directory(path, opts=None, timeout=6):
+    def upload_directory(path, opts=None):
         """Uploads directory at path with the given options."""
-        r = Skynet.upload_directory_request(path, opts, timeout=timeout)
+        r = Skynet.upload_directory_request(path, opts)
         sia_url = Skynet.uri_skynet_prefix() + r.json()["skylink"]
         r.close()
         return sia_url
 
     @staticmethod
-    def upload_directory_request(path, opts=None, timeout=6):
+    def upload_directory_request(path, opts=None):
         """Posts request to upload directory."""
         if not os.path.isdir(path):
             print("Given path is not a directory")
@@ -102,18 +111,22 @@ class Skynet:
         host = opts.portal_url
         path = opts.portal_upload_path
         url = "%s/%s?filename=%s" % (host, path, filename)
+        if hasattr(opts, 'timeout_seconds'):
+            timeout = opts.timeout_seconds
+        else:
+            timeout = Skynet.default_upload_options().timeout_seconds
         r = requests.post(url, files=ftuples, timeout=timeout)
         return r
 
     @staticmethod
-    def download_file(path, skylink, opts=None, timeout=6):
+    def download_file(path, skylink, opts=None):
         """Downloads file to path from given skylink with the given options."""
-        r = Skynet.download_file_request(skylink, opts, timeout=timeout)
+        r = Skynet.download_file_request(skylink, opts)
         open(path, 'wb').write(r.content)
         r.close()
 
     @staticmethod
-    def download_file_request(skylink, opts=None, stream=False, timeout=6):
+    def download_file_request(skylink, opts=None, stream=False):
         """Posts request to download file."""
         if opts is None:
             opts = Skynet.default_download_options()
@@ -121,17 +134,21 @@ class Skynet:
         portal = opts.portal_url
         skylink = Skynet.__strip_prefix(skylink)
         url = portal+'/'+skylink
+        if hasattr(opts, 'timeout_seconds'):
+            timeout = opts.timeout_seconds
+        else:
+            timeout = Skynet.default_upload_options().timeout_seconds
         r = requests.get(url, allow_redirects=True, stream=stream, timeout=timeout)
         return r
 
     @staticmethod
-    def metadata(skylink, opts=None, timeout=6):
+    def metadata(skylink, opts=None):
         """Downloads metadata from given skylink."""
-        r = Skynet.metadata_request(skylink, opts, timeout=timeout)
+        r = Skynet.metadata_request(skylink, opts)
         return json.loads(r.headers["skynet-file-metadata"])
 
     @staticmethod
-    def metadata_request(skylink, opts=None, stream=False, timeout=6):
+    def metadata_request(skylink, opts=None, stream=False):
         """Posts request to get metadata from given skylink."""
         if opts is None:
             opts = Skynet.default_download_options()
@@ -139,6 +156,10 @@ class Skynet:
         portal = opts.portal_url
         skylink = Skynet.__strip_prefix(skylink)
         url = portal+'/'+skylink
+        if hasattr(opts, 'timeout_seconds'):
+            timeout = opts.timeout_seconds
+        else:
+            timeout = Skynet.default_upload_options().timeout_seconds
         r = requests.head(url, allow_redirects=True, stream=stream, timeout=timeout)
         return r
 

--- a/siaskynet/skynet.py
+++ b/siaskynet/skynet.py
@@ -61,8 +61,8 @@ class Skynet:
                 timeout = opts.timeout_seconds
             else:
                 timeout = Skynet.default_upload_options().timeout_seconds
-            r = requests.post(url, files={opts.portal_file_fieldname: fd}, \
-                    timeout=timeout)
+            r = requests.post(url, files={opts.portal_file_fieldname: fd},
+                              timeout=timeout)
         return r
 
     @staticmethod
@@ -139,8 +139,8 @@ class Skynet:
             timeout = opts.timeout_seconds
         else:
             timeout = Skynet.default_upload_options().timeout_seconds
-        r = requests.get(url, allow_redirects=True, stream=stream, \
-                timeout=timeout)
+        r = requests.get(url, allow_redirects=True, stream=stream,
+                         timeout=timeout)
         return r
 
     @staticmethod
@@ -162,8 +162,8 @@ class Skynet:
             timeout = opts.timeout_seconds
         else:
             timeout = Skynet.default_upload_options().timeout_seconds
-        r = requests.head(url, allow_redirects=True, stream=stream, \
-                timeout=timeout)
+        r = requests.head(url, allow_redirects=True, stream=stream,
+                          timeout=timeout)
         return r
 
     @staticmethod

--- a/siaskynet/skynet.py
+++ b/siaskynet/skynet.py
@@ -41,13 +41,13 @@ class Skynet:
         return string
 
     @staticmethod
-    def upload_file(path, opts=None):
+    def upload_file(path, opts=None, timeout=6):
         """Uploads file at path with the given options."""
-        skylink = Skynet.upload_file_request(path, opts).json()["skylink"]
+        skylink = Skynet.upload_file_request(path, opts, timeout).json()["skylink"]
         return Skynet.uri_skynet_prefix() + skylink
 
     @staticmethod
-    def upload_file_request(path, opts=None):
+    def upload_file_request(path, opts=None, timeout=6):
         """Posts request to upload file."""
         if opts is None:
             opts = Skynet.default_upload_options()
@@ -56,11 +56,11 @@ class Skynet:
             host = opts.portal_url
             path = opts.portal_upload_path
             url = host+'/'+path
-            r = requests.post(url, files={opts.portal_file_fieldname: fd})
+            r = requests.post(url, files={opts.portal_file_fieldname: fd}, timeout=timeout)
         return r
 
     @staticmethod
-    def upload_file_request_with_chunks(path, opts=None):
+    def upload_file_request_with_chunks(path, opts=None, timeout=6):
         """Posts request to upload file with chunks."""
         if opts is None:
             opts = Skynet.default_upload_options()
@@ -70,19 +70,19 @@ class Skynet:
         url = "%s/%s?filename=%s" % \
             (opts.portal_url, opts.portal_upload_path, filename)
         headers = {'Content-Type': 'application/octet-stream'}
-        r = requests.post(url, data=path, headers=headers)
+        r = requests.post(url, data=path, headers=headers, timeout=timeout)
         return r
 
     @staticmethod
-    def upload_directory(path, opts=None):
+    def upload_directory(path, opts=None, timeout=6):
         """Uploads directory at path with the given options."""
-        r = Skynet.upload_directory_request(path, opts)
+        r = Skynet.upload_directory_request(path, opts, timeout=timeout)
         sia_url = Skynet.uri_skynet_prefix() + r.json()["skylink"]
         r.close()
         return sia_url
 
     @staticmethod
-    def upload_directory_request(path, opts=None):
+    def upload_directory_request(path, opts=None, timeout=6):
         """Posts request to upload directory."""
         if not os.path.isdir(path):
             print("Given path is not a directory")
@@ -102,18 +102,18 @@ class Skynet:
         host = opts.portal_url
         path = opts.portal_upload_path
         url = "%s/%s?filename=%s" % (host, path, filename)
-        r = requests.post(url, files=ftuples)
+        r = requests.post(url, files=ftuples, timeout=timeout)
         return r
 
     @staticmethod
-    def download_file(path, skylink, opts=None):
+    def download_file(path, skylink, opts=None, timeout=6):
         """Downloads file to path from given skylink with the given options."""
-        r = Skynet.download_file_request(skylink, opts)
+        r = Skynet.download_file_request(skylink, opts, timeout=timeout)
         open(path, 'wb').write(r.content)
         r.close()
 
     @staticmethod
-    def download_file_request(skylink, opts=None, stream=False):
+    def download_file_request(skylink, opts=None, stream=False, timeout=6):
         """Posts request to download file."""
         if opts is None:
             opts = Skynet.default_download_options()
@@ -121,17 +121,17 @@ class Skynet:
         portal = opts.portal_url
         skylink = Skynet.__strip_prefix(skylink)
         url = portal+'/'+skylink
-        r = requests.get(url, allow_redirects=True, stream=stream)
+        r = requests.get(url, allow_redirects=True, stream=stream, timeout=timeout)
         return r
 
     @staticmethod
-    def metadata(skylink, opts=None):
+    def metadata(skylink, opts=None, timeout=6):
         """Downloads metadata from given skylink."""
-        r = Skynet.metadata_request(skylink, opts)
+        r = Skynet.metadata_request(skylink, opts, timeout=timeout)
         return json.loads(r.headers["skynet-file-metadata"])
 
     @staticmethod
-    def metadata_request(skylink, opts=None, stream=False):
+    def metadata_request(skylink, opts=None, stream=False, timeout=6):
         """Posts request to get metadata from given skylink."""
         if opts is None:
             opts = Skynet.default_download_options()
@@ -139,7 +139,7 @@ class Skynet:
         portal = opts.portal_url
         skylink = Skynet.__strip_prefix(skylink)
         url = portal+'/'+skylink
-        r = requests.head(url, allow_redirects=True, stream=stream)
+        r = requests.head(url, allow_redirects=True, stream=stream, timeout=timeout)
         return r
 
     @staticmethod

--- a/siaskynet/skynet.py
+++ b/siaskynet/skynet.py
@@ -61,7 +61,8 @@ class Skynet:
                 timeout = opts.timeout_seconds
             else:
                 timeout = Skynet.default_upload_options().timeout_seconds
-            r = requests.post(url, files={opts.portal_file_fieldname: fd}, timeout=timeout)
+            r = requests.post(url, files={opts.portal_file_fieldname: fd}, \
+                    timeout=timeout)
         return r
 
     @staticmethod
@@ -138,7 +139,8 @@ class Skynet:
             timeout = opts.timeout_seconds
         else:
             timeout = Skynet.default_upload_options().timeout_seconds
-        r = requests.get(url, allow_redirects=True, stream=stream, timeout=timeout)
+        r = requests.get(url, allow_redirects=True, stream=stream, \
+                timeout=timeout)
         return r
 
     @staticmethod
@@ -160,7 +162,8 @@ class Skynet:
             timeout = opts.timeout_seconds
         else:
             timeout = Skynet.default_upload_options().timeout_seconds
-        r = requests.head(url, allow_redirects=True, stream=stream, timeout=timeout)
+        r = requests.head(url, allow_redirects=True, stream=stream, \
+                timeout=timeout)
         return r
 
     @staticmethod


### PR DESCRIPTION
This change is backwards compatible and plugs the edge cases where python requests may hang forever waiting for a reply.

I've moved the timeout parameter into the opts object as recommended in a different PR.  I added checks to keep the changes backwards compatible.

These are just my local changes.  I have not reviewed #20 to see whether it is a better solution than this.

