### PR TITLE
Fix up chunked uploading

### DIFF
--- a/siaskynet/__init__.py
+++ b/siaskynet/__init__.py
@@ -26,6 +26,7 @@ class SkynetClient():
     from ._upload import (
         upload, upload_request,
         upload_file, upload_file_request,
+        upload_file_with_chunks, upload_file_request_with_chunks,
         upload_directory, upload_directory_request
     )
     # pylint: enable=import-outside-toplevel

--- a/siaskynet/__init__.py
+++ b/siaskynet/__init__.py
@@ -24,7 +24,8 @@ class SkynetClient():
         get_skykeys
     )
     from ._upload import (
-        upload_file, upload_file_request, upload_file_request_with_chunks,
+        upload, upload_request,
+        upload_file, upload_file_request,
         upload_directory, upload_directory_request
     )
     # pylint: enable=import-outside-toplevel

--- a/siaskynet/_upload.py
+++ b/siaskynet/_upload.py
@@ -35,10 +35,12 @@ def upload_request(self, upload_data, custom_opts=None):
     if custom_opts is not None:
         opts.update(custom_opts)
 
-    filename = ''
     # Upload as a directory if the dirname is set, even if there is only 1
     # file.
-    if len(upload_data) == 1 and not opts['custom_dirname']:
+    issinglefile = len(upload_data) == 1 and not opts['custom_dirname']
+
+    filename = ''
+    if issinglefile:
         fieldname = opts['portal_file_fieldname']
     else:
         if not opts['custom_dirname']:
@@ -59,8 +61,7 @@ def upload_request(self, upload_data, custom_opts=None):
         ftuples.append((fieldname,
                         (filename, data)))
 
-    if opts['portal_file_fieldname'] == fieldname:
-        # single file
+    if issinglefile:
         data = ftuples[0][1][1]
         if hasattr(data, '__iter__') and (
                 not isinstance(data, bytes) and

--- a/siaskynet/_upload.py
+++ b/siaskynet/_upload.py
@@ -67,6 +67,7 @@ def upload_request(self, upload_data, custom_opts=None):
                 not isinstance(data, str) and
                 not hasattr(data, 'read')):
             # an iterator for chunked uploading
+            params['filename'] = ftuples[0][1][0]
             return self.execute_request(
                 "POST",
                 opts,

--- a/tests/test_integration_upload.py
+++ b/tests/test_integration_upload.py
@@ -273,7 +273,8 @@ def test_upload_file_chunks():
                     break
                 yield data
     chunks = chunker(src_file)
-    sialink2 = client.upload({'file1': chunks})
+    sialink2 = client.upload_file_with_chunks(chunks,
+                                              {'custom_filename': src_file})
     if SIALINK != sialink2:
         sys.exit("ERROR: expected returned sialink "+SIALINK +
                  ", received "+sialink2)

--- a/tests/test_integration_upload.py
+++ b/tests/test_integration_upload.py
@@ -246,3 +246,45 @@ filename="dir1/file2"') != -1
 filename="file0"') == -1
 
     assert len(responses.calls) == 1
+
+
+@responses.activate
+def test_upload_file_chunks():
+    """Test uploading a file with chunks."""
+
+    src_file = "./testdata/file1"
+
+    # upload a file
+
+    responses.add(
+        responses.POST,
+        'https://siasky.net/skynet/skyfile',
+        json={'skylink': SKYLINK},
+        status=200
+    )
+
+    print("Uploading file "+src_file)
+
+    def chunker(filename):
+        with open(filename, 'rb') as file:
+            while True:
+                data = file.read(3)
+                if not data:
+                    break
+                yield data
+    chunks = chunker(src_file)
+    sialink2 = client.upload({'file1': chunks})
+    if SIALINK != sialink2:
+        sys.exit("ERROR: expected returned sialink "+SIALINK +
+                 ", received "+sialink2)
+    print("File upload successful, sialink: " + sialink2)
+
+    headers = responses.calls[0].request.headers
+    assert headers["Transfer-Encoding"] == "chunked"
+    assert headers["User-Agent"] == "python-requests/2.24.0"
+    assert "Authorization" not in headers
+
+    body = responses.calls[0].request.body
+    assert body is chunks
+
+    assert len(responses.calls) == 1


### PR DESCRIPTION
Somehow in transitions it looks like the chunked uploading feature broke.

This change fixes it up again.

Chunked uploading is done by passing an iterator as the body data; see https://requests.readthedocs.io/en/master/user/advanced/#chunk-encoded-requests

I believe you can also pass a file-like object to stream with known size for #30