### PR TITLE
Streaming uploads

### DIFF
--- a/siaskynet/_upload.py
+++ b/siaskynet/_upload.py
@@ -62,20 +62,15 @@ def upload_request(self, upload_data, custom_opts=None):
                         (filename, data)))
 
     if issinglefile:
-        data = ftuples[0][1][1]
-        if hasattr(data, '__iter__') and (
-                not isinstance(data, bytes) and
-                not isinstance(data, str) and
-                not hasattr(data, 'read')):
-            # an iterator for chunked uploading
-            params['filename'] = ftuples[0][1][0]
-            return self.execute_request(
-                "POST",
-                opts,
-                data=data,
-                headers={'Content-Type': 'application/octet-stream'},
-                params=params
-            )
+        filename, data = ftuples[0][1]
+        params['filename'] = filename
+        return self.execute_request(
+            "POST",
+            opts,
+            data=data,
+            headers={'Content-Type': 'application/octet-stream'},
+            params=params
+        )
     return self.execute_request(
         "POST",
         opts,

--- a/tests/test_integration_upload.py
+++ b/tests/test_integration_upload.py
@@ -22,11 +22,11 @@ def response_callback(request):
     # process body content
     if hasattr(request.body, 'read'):
         # upload is a file object
-	# read the file and store its content for test to compare
+        # read the file and store its content for test to compare
         request.body = request.body.read()
     elif not isinstance(request.body, (str, bytes)):
         # upload is a chunked iterator
-	# convert it into the iterated content
+        # convert it into the iterated content
         chunks = [*request.body]
         if len(chunks) > 0 and isinstance(chunks[0], str):
             request.body = ''.join(chunks)

--- a/tests/test_integration_upload.py
+++ b/tests/test_integration_upload.py
@@ -14,15 +14,27 @@ client = skynet.SkynetClient()
 
 
 def response_callback(request):
-    """Called by responses for HTTP requests"""
+    """Called by responses for HTTP requests.
+       This function can perform any processing of
+       requests needed for tests.
+    """
+
+    # process body content
     if hasattr(request.body, 'read'):
+        # upload is a file object
+	# read the file and store its content for test to compare
         request.body = request.body.read()
     elif not isinstance(request.body, (str, bytes)):
+        # upload is a chunked iterator
+	# convert it into the iterated content
         chunks = [*request.body]
         if len(chunks) > 0 and isinstance(chunks[0], str):
             request.body = ''.join(chunks)
         else:
             request.body = b''.join(chunks)
+
+    # return the status code and headers for
+    # the responses module to provide
     return (
         200,
         {'Content-Type': 'application/json'},


### PR DESCRIPTION
This is an extension on #36 to stream all files.

python-requests streams file objects and iterators if they are passed as post body content.  I've changed all single file uploads to upload in that way.